### PR TITLE
Adds RSSI WiFi Bar Icon

### DIFF
--- a/Adafruit_FeatherOLED_WiFi.cpp
+++ b/Adafruit_FeatherOLED_WiFi.cpp
@@ -37,6 +37,30 @@
 
 /******************************************************************************/
 /*!
+    @brief  Converts RSSI from dBm to quality percentage
+*/
+/******************************************************************************/
+int Adafruit_FeatherOLED_WiFi::rssiToQualityPercentage( void )
+{
+  int quality;
+  if(_rssi <= -100)
+  {
+    quality = 0;
+  }
+  else if(_rssi >= -50)
+  {
+    quality = 100;
+  }
+  else
+  {
+    quality = 2 * (_rssi + 100);
+  } 
+
+  return quality;
+}
+
+/******************************************************************************/
+/*!
     @brief  Renders the RSSI icon
 */
 /******************************************************************************/
@@ -45,26 +69,21 @@ void Adafruit_FeatherOLED_WiFi::renderRSSI( void )
   if (_rssiVisible)
   {
     setCursor(0,0);
-    print("RSSI:");
+
     if (_connected)
     {
+      renderRSSIIcon();
+
       if(_rssiAsPercentage)
       {
-        int quality;
-        if(_rssi <= -100)
+        int quality = rssiToQualityPercentage();
+        if(quality == 0)
         {
-          quality = 0;
           print("---");
-        }
-        else if(_rssi >= -50)
-        {
-          quality = 100;
-          print("100%");
         }
         else
         {
-          quality = 2 * (_rssi + 100);
-          char buf[4];
+          char buf[5];
           itoa(quality, buf, 10);
           strcat(buf, "%");
           print(buf);
@@ -73,12 +92,79 @@ void Adafruit_FeatherOLED_WiFi::renderRSSI( void )
       else
       {
         print(_rssi);
+        print(" dBm");
       }
     }
     else
     {
+      print("RSSI:");
       print("---");
     }
+  }
+}
+
+/******************************************************************************/
+/*!
+    @brief  Renders the WiFi icon
+*/
+/******************************************************************************/
+void Adafruit_FeatherOLED_WiFi::renderRSSIIcon ( void )
+{
+  #define RSSITEXT_STARTX      14
+  #define RSSITEXT_STARTY      0
+  #define RSSIICON_STARTX      0
+  #define RSSIICON_STARTY      4
+  #define RSSIICON_STARTHEIGHT 3
+  #define RSSIICON_BARWIDTH    2
+
+  if(_rssiIcon)
+  {
+    int quality = rssiToQualityPercentage();
+    if(quality == 0)
+    {
+      print("---");
+    }
+    else
+    {
+      fillRect(RSSIICON_STARTX, 
+               RSSIICON_STARTY,
+               RSSIICON_BARWIDTH,
+               RSSIICON_STARTHEIGHT,
+               WHITE);
+    }
+
+    if(quality >= 45)
+    {
+      fillRect(RSSIICON_STARTX + 3, 
+               RSSIICON_STARTY - 1,
+               RSSIICON_BARWIDTH,
+               RSSIICON_STARTHEIGHT + 1,
+               WHITE);      
+    }
+
+    if(quality >= 70)
+    {
+      fillRect(RSSIICON_STARTX + 6, 
+               RSSIICON_STARTY - 2,
+               RSSIICON_BARWIDTH,
+               RSSIICON_STARTHEIGHT + 2,
+               WHITE);      
+    }
+
+    if(quality >= 90)
+    {
+      fillRect(RSSIICON_STARTX + 9, 
+               RSSIICON_STARTY - 4,
+               RSSIICON_BARWIDTH,
+               RSSIICON_STARTHEIGHT + 4,
+               WHITE);
+    }
+
+    setCursor(RSSITEXT_STARTX, RSSITEXT_STARTY);
+  }
+  else
+  {
+    print("RSSI:");
   }
 }
 

--- a/Adafruit_FeatherOLED_WiFi.h
+++ b/Adafruit_FeatherOLED_WiFi.h
@@ -44,16 +44,21 @@
 
 class Adafruit_FeatherOLED_WiFi : public Adafruit_FeatherOLED
 {
+  private: 
+    int rssiToQualityPercentage ( void );
+
   protected:
     bool    _connected;
     bool    _connectedVisible;
     int     _rssi;
+    bool    _rssiIcon;
     bool    _rssiAsPercentage;
     bool    _rssiVisible;
     int32_t _ipAddress;
     bool    _ipAddressVisible;
 
     void renderRSSI       ( void );
+    void renderRSSIIcon   ( void );
     void renderConnected  ( void );
     void renderIPAddress  ( void );
 
@@ -65,6 +70,7 @@ class Adafruit_FeatherOLED_WiFi : public Adafruit_FeatherOLED
       _connected          = false;
       _connectedVisible   = true;
       _rssi               = -99;
+      _rssiIcon           = false;
       _rssiAsPercentage   = false;
       _rssiVisible        = true;
       _ipAddress          = 0;
@@ -74,6 +80,7 @@ class Adafruit_FeatherOLED_WiFi : public Adafruit_FeatherOLED
     void setConnected        ( bool conn )      { _connected = conn; }
     void setConnectedVisible ( bool enable )    { _connectedVisible = enable; }
     void setRSSI             ( int rssi )       { _rssi = rssi; }
+    void setRSSIIcon         ( bool enable )    { _rssiIcon = enable; }
     void setRSSIAsPercentage ( bool enable )    { _rssiAsPercentage = enable; }
     void setRSSIVisible      ( bool enable )    { _rssiVisible = enable; }
     void setIPAddress        ( uint32_t addr )  { _ipAddress = addr; }


### PR DESCRIPTION
Adds ability to display WiFi signal strength as a bar icon instead of
renderng the "RSSI" text label.